### PR TITLE
fix cache header hook in performance file

### DIFF
--- a/inc/performance.php
+++ b/inc/performance.php
@@ -119,7 +119,8 @@ function sacred_signal_add_expires_headers() {
         header('Expires: ' . gmdate('D, d M Y H:i:s', time() + 31536000) . ' GMT');
     }
 }
-add_action('wp_head', 'sacred_signal_add_expires_headers', 1);
+// Use send_headers to set cache headers before any output
+add_action('send_headers', 'sacred_signal_add_expires_headers');
 
 /**
  * Optimize CSS delivery


### PR DESCRIPTION
## Summary
- use `send_headers` action to add cache headers before output

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type, @typescript-eslint/no-require-imports)*
- `php -l inc/performance.php`


------
https://chatgpt.com/codex/tasks/task_e_68c503bc24c08332b9b33e17bd3649e5