### PR TITLE
Fix font weight and meta tags for Lovable parity

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -70,7 +70,13 @@ function sacred_signal_os_scripts() {
     $theme_uri = get_template_directory_uri();
 
     // Google Fonts with proper display swap
-    wp_enqueue_style('google-fonts', 'https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap', array(), null);
+    // Include heavier 900 weight for Playfair Display to match Lovable design
+    wp_enqueue_style(
+        'google-fonts',
+        'https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700;900&display=swap',
+        array(),
+        null
+    );
 
     // Base style.css (versioned with filemtime for cache busting)
     $style_path = $theme_dir . '/style.css';

--- a/header.php
+++ b/header.php
@@ -24,6 +24,10 @@
     
     <!-- SEO and Performance -->
     <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
+    <meta name="description" content="<?php echo esc_attr( get_bloginfo( 'description' ) ); ?>">
+    <meta property="og:title" content="<?php echo esc_attr( wp_get_document_title() ); ?>">
+    <meta property="og:description" content="<?php echo esc_attr( get_bloginfo( 'description' ) ); ?>">
+    <meta property="og:type" content="website">
     
     <?php wp_head(); ?>
 </head>

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,8 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+// Use a type alias rather than an empty interface to satisfy linting rules
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+// Use a type alias rather than an empty interface to satisfy linting rules
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(({ className, ...props }, ref) => {
   return (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
   darkMode: ["class"],
@@ -100,5 +101,6 @@ export default {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  // Use ESM import for plugins to satisfy lint rules
+  plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- include Playfair Display 900 weight for full typography parity
- add meta description and OG tags to header
- resolve lint errors in UI components and Tailwind config

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c50c94ae348332b8121e75b7822eb4